### PR TITLE
Fix setting a priority on Rule and stardize parsing priority from input

### DIFF
--- a/rulesengine/condition.go
+++ b/rulesengine/condition.go
@@ -24,6 +24,10 @@ type Condition struct {
 	Not        *Condition
 }
 
+func (c *Condition) SetPriority(priority int) {
+	c.Priority = priority
+}
+
 // NewCondition creates a new Condition instance
 func NewCondition(properties map[string]interface{}) (*Condition, error) {
 	if properties == nil {
@@ -44,12 +48,10 @@ func NewCondition(properties map[string]interface{}) (*Condition, error) {
 
 		cond.Operator = booleanOperator
 
-		if priority, ok := properties["priority"]; ok {
-			if p, ok := priority.(float64); ok {
-				cond.Priority = int(p)
-			} else {
-				cond.Priority = 1
-			}
+		if priority, err := ParsePriority(properties); err == nil {
+			cond.Priority = priority
+		} else if err.Code == "INVALID_PRIORITY_TYPE" || err.Code == "INVALID_PRIORITY_VALUE" {
+			return nil, err
 		} else {
 			cond.Priority = 1
 		}
@@ -100,8 +102,10 @@ func NewCondition(properties map[string]interface{}) (*Condition, error) {
 		}
 		cond.Operator = properties["operator"].(string)
 		cond.Value = properties["value"]
-		if priority, ok := properties["priority"]; ok {
-			cond.Priority = int(priority.(float64))
+		if priority, err := ParsePriority(properties); err == nil {
+			cond.Priority = priority
+		} else if err.Code == "INVALID_PRIORITY_TYPE" || err.Code == "INVALID_PRIORITY_VALUE" {
+			return nil, err
 		}
 	}
 

--- a/rulesengine/condition_test.go
+++ b/rulesengine/condition_test.go
@@ -1,0 +1,100 @@
+package rulesengine
+
+import (
+	"testing"
+)
+
+func TestNewCondition(t *testing.T) {
+	t.Run("Valid priority types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			priority interface{}
+			expected int
+		}{
+			{"float64", float64(2.0), 2},
+			{"float32", float32(2.0), 2},
+			{"int64", int64(3), 3},
+			{"int", 4, 4},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				conditions := map[string]interface{}{
+					"all": []interface{}{
+						map[string]interface{}{
+							"fact":     "age",
+							"operator": "greaterThan",
+							"value":    18,
+							"priority": tc.priority,
+						},
+					},
+				}
+
+				condition, err := NewCondition(conditions)
+				if err != nil {
+					t.Errorf("Expected condition creation to succeed, but got error: %v", err)
+				}
+				if condition.All[0].Priority != tc.expected {
+					t.Errorf("Expected priority to be %d, but got %d", tc.expected, condition.All[0].Priority)
+				}
+			})
+		}
+	})
+
+	t.Run("Invalid priority types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			priority interface{}
+		}{
+			{"string", "invalid"},
+			{"bool", true},
+			{"slice", []int{1, 2, 3}},
+			{"map", map[string]int{"priority": 5}},
+			{"negative int", -1},
+			{"zero", 0},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				conditions := map[string]interface{}{
+					"all": []interface{}{
+						map[string]interface{}{
+							"fact":     "age",
+							"operator": "greaterThan",
+							"value":    18,
+							"priority": tc.priority,
+						},
+					},
+				}
+
+				condition, err := NewCondition(conditions)
+				if err == nil {
+					t.Errorf("Expected condition creation to fail, but got no error")
+				}
+				if condition != nil {
+					t.Errorf("Expected condition to be nil, but got %v", condition)
+				}
+			})
+		}
+	})
+
+	t.Run("Default priority", func(t *testing.T) {
+		conditions := map[string]interface{}{
+			"all": []interface{}{
+				map[string]interface{}{
+					"fact":     "age",
+					"operator": "greaterThan",
+					"value":    18,
+				},
+			},
+		}
+
+		condition, err := NewCondition(conditions)
+		if err != nil {
+			t.Errorf("Expected condition creation to succeed, but got error: %v", err)
+		}
+		if condition.All[0].Priority != 0 {
+			t.Errorf("Expected priority to be 0 (default), but got %d", condition.All[0].Priority)
+		}
+	})
+}

--- a/rulesengine/errors.go
+++ b/rulesengine/errors.go
@@ -20,3 +20,32 @@ func NewUndefinedFactError(message string) *UndefinedFactError {
 		Code:    "UNDEFINED_FACT",
 	}
 }
+
+// InvalidRuleError represents an error for an invalid rule
+type InvalidRuleError struct {
+	Message string
+	Code    string
+}
+
+func (e *InvalidRuleError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func NewInvalidRuleError(message string, code string) *InvalidRuleError {
+	return &InvalidRuleError{
+		Message: message,
+		Code:    code,
+	}
+}
+
+func NewInvalidPriorityTypeError() *InvalidRuleError {
+	return NewInvalidRuleError("Priority must be an integer", "INVALID_PRIORITY_TYPE")
+}
+
+func NewInvalidPriorityValueError() *InvalidRuleError {
+	return NewInvalidRuleError("Priority must be greater than zero", "INVALID_PRIORITY_VALUE")
+}
+
+func NewPriorityNotSetError() *InvalidRuleError {
+	return NewInvalidRuleError("Priority not set", "PRIORITY_NOT_SET")
+}

--- a/rulesengine/rule_test.go
+++ b/rulesengine/rule_test.go
@@ -1,0 +1,91 @@
+package rulesengine
+
+import (
+	"testing"
+)
+
+func TestNewRule(t *testing.T) {
+	t.Run("Valid priority types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			priority interface{}
+			expected int
+		}{
+			{"float64", float64(2.0), 2},
+			{"float", float32(2.0), 2},
+			{"int64", int64(3), 3},
+			{"int", 4, 4},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				options := map[string]interface{}{
+					"name":     "Test Rule",
+					"priority": tc.priority,
+					"conditions": map[string]interface{}{
+						"all": []interface{}{},
+					},
+				}
+
+				rule, err := NewRule(options)
+				if err != nil {
+					t.Errorf("Expected rule creation to succeed, but got error: %v", err)
+				}
+				if rule.Priority != tc.expected {
+					t.Errorf("Expected priority to be %d, but got %d", tc.expected, rule.Priority)
+				}
+			})
+		}
+	})
+
+	t.Run("Invalid priority types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			priority interface{}
+		}{
+			{"string", "invalid"},
+			{"bool", true},
+			{"slice", []int{1, 2, 3}},
+			{"map", map[string]int{"priority": 5}},
+			{"negative int", -1},
+			{"zero", 0},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				options := map[string]interface{}{
+					"name":     "Test Rule",
+					"priority": tc.priority,
+					"conditions": map[string]interface{}{
+						"all": []interface{}{},
+					},
+				}
+
+				rule, err := NewRule(options)
+				if err == nil {
+					t.Errorf("Expected rule creation to fail, but got no error")
+				}
+				if rule != nil {
+					t.Errorf("Expected rule to be nil, but got %v", rule)
+				}
+			})
+		}
+	})
+
+	t.Run("Default priority", func(t *testing.T) {
+		options := map[string]interface{}{
+			"name": "Test Rule",
+			"conditions": map[string]interface{}{
+				"all": []interface{}{},
+			},
+		}
+
+		rule, err := NewRule(options)
+		if err != nil {
+			t.Errorf("Expected rule creation to succeed, but got error: %v", err)
+		}
+		if rule.Priority != 1 {
+			t.Errorf("Expected priority to be 1 (default), but got %d", rule.Priority)
+		}
+	})
+}

--- a/rulesengine/utils.go
+++ b/rulesengine/utils.go
@@ -17,3 +17,31 @@ func DeepCopy(src, dst interface{}) error {
 	}
 	return json.Unmarshal(bytes, dst)
 }
+
+func ParsePriority(properties map[string]interface{}) (int, *InvalidRuleError) {
+	var result int
+	var err *InvalidRuleError
+
+	if _, exists := properties["priority"]; exists {
+		switch priority := properties["priority"].(type) {
+		case float64:
+			result = int(priority)
+		case float32:
+			result = int(priority)
+		case int64:
+			result = int(priority)
+		case int:
+			result = priority
+		default:
+			err = NewInvalidPriorityTypeError()
+		}
+
+		if result <= 0 {
+			err = NewInvalidPriorityValueError()
+		}
+	} else {
+		err = NewPriorityNotSetError()
+	}
+
+	return result, err
+}


### PR DESCRIPTION
## Summary

Fixes a bug where setting `Rule.Priority` from JSON input was not working (because `setName` was used internally), causing rule execution order not to be respected.

- Standardize parsing `priority` from arguments for `Rule` and `Condition`, while preserving its defaults (`1` and `0` respectively)
- Given the package doesn't have a testing strategy in place yet, this PR introduces very simple/non-opinionated tests, specifically targeting this change
- Introduce a pseudo-generic `InvalidRule` error and specific `Priority` errors/codes (missing, invalid type and invalid value)